### PR TITLE
Lifecycle fases voor broncode en Open BSW diensten.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Mijn Bureau is een samenwerking van de Rijksoverheid, Gemeente Amsterdam en de V
 
 Vanuit de Rijksoverheid werkt het projectteam van Open BSW van het programma Beter SamenWerken aan Mijn Bureau. Zij documenteren hun werkwijze, proces en geleerde lessen in deze repository in de [map openbsw](openbsw/index.md).
 
+## Lifecycle fases voor broncode
+
+Om onderscheid te maken tussen de broncode van de componenten en in welke mate ze bruikbaar zijn merken we de code aan met de lifecycle phases uit de PublicCode.yml standaard:
+
+-  Concept (`concept`) - De software is een “concept”. Er is geen code ontwikkeld die werkt of de repository is leeg. 
+-  In ontwikkeling (`development`) - Er is software ontwikkeld welke nog niet klaar is voor de eindgebruiker, ook nog niet om uit te proberen.
+-  Proef (`beta`) - De software is in een The software is in een beproevingsfase.
+-  Stabiel (`stable`) - De software is in productie en kan als dienst worden aangeboden.
+-  Verouderd (`obsolete`) - De software word niet meer onderhouden.
+
 ---
 
 Licentie: In licentie gegeven krachtens de [EUPL (Openbare Licentie van de Europese Unie 1.2 of hoger)](LICENCE.md)

--- a/openbsw/lifecycle-diensten.md
+++ b/openbsw/lifecycle-diensten.md
@@ -1,0 +1,10 @@
+# Lifecycle van Open BSW diensten
+
+Op basis van de Mijn Bureau componenten bieden we diensten aan voor gebruik binnen de Rijksoverheid.
+Om duidelijk te maken in welke mate een component gebruikt kan worden worden ze duidelijk gemarkeerd met in welke fase van de uitrol ze zitten.
+
+Fases:
+
+- In ontwikkeling: de dienst kan nog niet gebruikt worden door eindgebruikers, word hij wel gebruikt is hier geen ondersteuning voor en kan de data op elk moment verdwijnen.
+- Proef: de dienst word door een selecte groep gebruikers getest met een beperkte afgesproken set aan garanties, ondersteuning en doorontwikkeling.
+- Productie: de dienst kan gebruikt worden voor alle gebruikers met ondersteuning en doorontwikkeling.


### PR DESCRIPTION
Definitie van de lifecycle fases voor zowel broncode als de diensten die we vanuit BSW aan de Rijksoverheid willen leveren.

Ik vroeg me nog af of de BSW diensten ook nog een 'obsolete' stadium nodig hebben voor apps die we wel laten draaien maar die we niet willen ondersteunen.

Fixes #35